### PR TITLE
Update cryptofuzz submodule URL to MozillaSecurity repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cryptofuzz"]
 	path = cryptofuzz
-	url = https://github.com/paulmillr/cryptofuzz.git
+	url = https://github.com/MozillaSecurity/cryptofuzz


### PR DESCRIPTION
- Changed URL from https://github.com/paulmillr/cryptofuzz.git to https://github.com/MozillaSecurity/cryptofuzz
- Updated submodule to latest commit from new repository